### PR TITLE
Support record identifier transform

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 
-from .models import Organization, RecordGroup, Job, Record, OAIEndpoint, LivySession, Transformation, ValidationScenario
+from .models import Organization, RecordGroup, Job, Record, OAIEndpoint, LivySession, Transformation, ValidationScenario, RecordIdentifierTransformationScenario
 
 # register models
-admin.site.register([Organization, RecordGroup, Job, Record, OAIEndpoint, LivySession, Transformation, ValidationScenario])
+admin.site.register([Organization, RecordGroup, Job, Record, OAIEndpoint, LivySession, Transformation, ValidationScenario, RecordIdentifierTransformationScenario])

--- a/core/models.py
+++ b/core/models.py
@@ -1797,7 +1797,7 @@ class RecordIdentifierTransformationScenario(models.Model):
 	name = models.CharField(max_length=255)
 	transformation_type = models.CharField(
 		max_length=255,
-		choices=[('regex','Java Regular Expressions'),('python','Python Code Snippet'),('xpath','XPath Expression')]
+		choices=[('regex','Python Regular Expression'),('python','Python Code Snippet'),('xpath','XPath Expression')]
 	)
 	transformation_target = models.CharField(
 		max_length=255,
@@ -3259,6 +3259,7 @@ class HarvestOAIJob(HarvestJob):
 			self.oai_endpoint = oai_endpoint
 			self.overrides = overrides
 			self.validation_scenarios = validation_scenarios
+			self.rits = rits
 
 			# write validation links
 			if len(self.validation_scenarios) > 0:
@@ -3382,6 +3383,9 @@ class HarvestStaticXMLJob(HarvestJob):
 
 			# get validation scenarios
 			self.validation_scenarios = validation_scenarios
+
+			# rits
+			self.rits = rits
 
 			# write validation links
 			if len(self.validation_scenarios) > 0:
@@ -3631,6 +3635,7 @@ class TransformJob(CombineJob):
 			self.transformation = transformation
 			self.index_mapper = index_mapper
 			self.validation_scenarios = validation_scenarios
+			self.rits = rits
 
 			# if job name not provided, provide default
 			if not self.job_name:
@@ -4009,6 +4014,7 @@ class AnalysisJob(CombineJob):
 			self.input_jobs = input_jobs
 			self.index_mapper = index_mapper
 			self.validation_scenarios = validation_scenarios
+			self.rits = rits
 
 			# if job name not provided, provide default
 			if not self.job_name:

--- a/core/models.py
+++ b/core/models.py
@@ -1788,6 +1788,32 @@ class IndexMappers(object):
 
 
 
+class RecordIdentifierTransformationScenario(models.Model):
+
+	'''
+	Model to manage transformation scenarios for Record's record_ids
+	'''
+
+	name = models.CharField(max_length=255)
+	transformation_type = models.CharField(
+		max_length=255,
+		choices=[('regex','Regular Expressions'),('python','Python Code Snippet'),('xpath','XPath Expression')]
+	)
+	transformation_target = models.CharField(
+		max_length=255,
+		choices=[('record_id','Record Identifier'),('document','Record Document')]
+	)
+	regex_match_payload = models.CharField(null=True, default=None, max_length=4096, blank=True)
+	regex_replace_payload = models.CharField(null=True, default=None, max_length=4096, blank=True)
+	python_payload = models.TextField(null=True, default=None, blank=True)
+	xpath_payload = models.CharField(null=True, default=None, max_length=4096, blank=True)
+	default_run = models.BooleanField(default=0)
+
+	def __str__(self):
+		return '%s, RITS: #%s' % (self.name, self.id)
+
+
+
 ####################################################################
 # Signals Handlers                                                 # 
 ####################################################################
@@ -4714,6 +4740,15 @@ class RecordIDTransformationScenario(object):
 			'results':trans_result
 		}		
 		return r_dict
+
+
+	def params_as_json(self):
+
+		'''
+		Method to generate the required parameters to include in Spark job
+		'''
+
+		return json.dumps(self.__dict__)
 
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -3223,7 +3223,8 @@ class HarvestOAIJob(HarvestJob):
 		index_mapper=None,
 		oai_endpoint=None,
 		overrides=None,
-		validation_scenarios=[]):
+		validation_scenarios=[],
+		rits=None):
 
 		'''
 		Args:
@@ -3288,7 +3289,7 @@ class HarvestOAIJob(HarvestJob):
 
 		# prepare job code
 		job_code = {
-			'code':'from jobs import HarvestOAISpark\nHarvestOAISpark.spark_function(spark, endpoint="%(endpoint)s", verb="%(verb)s", metadataPrefix="%(metadataPrefix)s", scope_type="%(scope_type)s", scope_value="%(scope_value)s", job_id="%(job_id)s", index_mapper="%(index_mapper)s", validation_scenarios="%(validation_scenarios)s")' % 
+			'code':'from jobs import HarvestOAISpark\nHarvestOAISpark.spark_function(spark, endpoint="%(endpoint)s", verb="%(verb)s", metadataPrefix="%(metadataPrefix)s", scope_type="%(scope_type)s", scope_value="%(scope_value)s", job_id="%(job_id)s", index_mapper="%(index_mapper)s", validation_scenarios="%(validation_scenarios)s", rits="%(rits)s")' % 
 			{
 				'endpoint':harvest_vars['endpoint'],
 				'verb':harvest_vars['verb'],
@@ -3297,7 +3298,8 @@ class HarvestOAIJob(HarvestJob):
 				'scope_value':harvest_vars['scope_value'],
 				'job_id':self.job.id,
 				'index_mapper':self.index_mapper,
-				'validation_scenarios':str([ int(vs_id) for vs_id in self.validation_scenarios ])
+				'validation_scenarios':str([ int(vs_id) for vs_id in self.validation_scenarios ]),
+				'rits':self.rits
 			}
 		}
 
@@ -3331,7 +3333,8 @@ class HarvestStaticXMLJob(HarvestJob):
 		job_id=None,
 		index_mapper=None,
 		payload_dict=None,
-		validation_scenarios=[]):
+		validation_scenarios=[],
+		rits=None):
 
 		'''
 		Args:
@@ -3551,7 +3554,7 @@ class HarvestStaticXMLJob(HarvestJob):
 
 		# prepare job code
 		job_code = {
-			'code':'from jobs import HarvestStaticXMLSpark\nHarvestStaticXMLSpark.spark_function(spark, static_type="%(static_type)s", static_payload="%(static_payload)s", xpath_document_root="%(xpath_document_root)s", xpath_record_id="%(xpath_record_id)s", job_id="%(job_id)s", index_mapper="%(index_mapper)s", validation_scenarios="%(validation_scenarios)s")' % 
+			'code':'from jobs import HarvestStaticXMLSpark\nHarvestStaticXMLSpark.spark_function(spark, static_type="%(static_type)s", static_payload="%(static_payload)s", xpath_document_root="%(xpath_document_root)s", xpath_record_id="%(xpath_record_id)s", job_id="%(job_id)s", index_mapper="%(index_mapper)s", validation_scenarios="%(validation_scenarios)s", rits="%(rits)s")' % 
 			{
 				'static_type':self.payload_dict['type'],
 				'static_payload':self.payload_dict['payload_dir'],
@@ -3559,7 +3562,8 @@ class HarvestStaticXMLJob(HarvestJob):
 				'xpath_record_id':self.payload_dict['xpath_record_id'],
 				'job_id':self.job.id,
 				'index_mapper':self.index_mapper,
-				'validation_scenarios':str([ int(vs_id) for vs_id in self.validation_scenarios ])
+				'validation_scenarios':str([ int(vs_id) for vs_id in self.validation_scenarios ]),
+				'rits':self.rits
 			}
 		}
 
@@ -3592,7 +3596,8 @@ class TransformJob(CombineJob):
 		transformation=None,
 		job_id=None,
 		index_mapper=None,
-		validation_scenarios=[]):
+		validation_scenarios=[],
+		rits=None):
 
 		'''
 		Args:
@@ -3684,13 +3689,14 @@ class TransformJob(CombineJob):
 
 		# prepare job code
 		job_code = {
-			'code':'from jobs import TransformSpark\nTransformSpark.spark_function(spark, transformation_id="%(transformation_id)s", input_job_id="%(input_job_id)s", job_id="%(job_id)s", index_mapper="%(index_mapper)s", validation_scenarios="%(validation_scenarios)s")' % 
+			'code':'from jobs import TransformSpark\nTransformSpark.spark_function(spark, transformation_id="%(transformation_id)s", input_job_id="%(input_job_id)s", job_id="%(job_id)s", index_mapper="%(index_mapper)s", validation_scenarios="%(validation_scenarios)s", rits="%(rits)s")' % 
 			{
 				'transformation_id':self.transformation.id,				
 				'input_job_id':self.input_job.id,
 				'job_id':self.job.id,
 				'index_mapper':self.index_mapper,
-				'validation_scenarios':str([ int(vs_id) for vs_id in self.validation_scenarios ])
+				'validation_scenarios':str([ int(vs_id) for vs_id in self.validation_scenarios ]),
+				'rits':self.rits
 			}
 		}
 
@@ -3973,7 +3979,8 @@ class AnalysisJob(CombineJob):
 		input_jobs=None,
 		job_id=None,
 		index_mapper=None,
-		validation_scenarios=[]):
+		validation_scenarios=[],
+		rits=None):
 
 		'''
 		Args:
@@ -4121,12 +4128,13 @@ class AnalysisJob(CombineJob):
 
 		# prepare job code
 		job_code = {
-			'code':'from jobs import MergeSpark\nMergeSpark.spark_function(spark, sc, input_jobs_ids="%(input_jobs_ids)s", job_id="%(job_id)s", index_mapper="%(index_mapper)s", validation_scenarios="%(validation_scenarios)s")' % 
+			'code':'from jobs import MergeSpark\nMergeSpark.spark_function(spark, sc, input_jobs_ids="%(input_jobs_ids)s", job_id="%(job_id)s", index_mapper="%(index_mapper)s", validation_scenarios="%(validation_scenarios)s", rits="%(rits)s")' % 
 			{
 				'input_jobs_ids':str([ input_job.id for input_job in self.input_jobs ]),
 				'job_id':self.job.id,
 				'index_mapper':self.index_mapper,
-				'validation_scenarios':str([ int(vs_id) for vs_id in self.validation_scenarios ])
+				'validation_scenarios':str([ int(vs_id) for vs_id in self.validation_scenarios ]),
+				'rits':self.rits
 			}
 		}
 

--- a/core/models.py
+++ b/core/models.py
@@ -4645,7 +4645,6 @@ class RecordIDTransformationScenario(object):
 	def __init__(self, query_dict):
 
 		logger.debug('initializaing RITS')
-		logger.debug(query_dict)
 
 		self.qd = query_dict
 
@@ -4689,9 +4688,6 @@ class RecordIDTransformationScenario(object):
 
 		# capture test data if
 		self.test_input = self.qd.get('test_transform_input', None)
-
-		# DEBUG
-		logger.debug(self.__dict__)
 
 
 	def test_user_input(self):
@@ -4740,7 +4736,8 @@ class RecordIDTransformationScenario(object):
 
 		# return dict
 		r_dict = {
-			'results':trans_result
+			'results':trans_result,
+			'success':True
 		}		
 		return r_dict
 

--- a/core/models.py
+++ b/core/models.py
@@ -4690,6 +4690,9 @@ class RecordIDTransformationScenario(object):
 		# capture test data if
 		self.test_input = self.qd.get('test_transform_input', None)
 
+		# DEBUG
+		logger.debug(self.__dict__)
+
 
 	def test_user_input(self):
 

--- a/core/models.py
+++ b/core/models.py
@@ -4618,7 +4618,6 @@ class RecordIDTransformationScenario(object):
 
 	def __init__(self, query_dict):
 
-		logger.debug("##########################################")
 		logger.debug('initializaing RITS')
 		logger.debug(query_dict)
 
@@ -4664,8 +4663,6 @@ class RecordIDTransformationScenario(object):
 
 		# capture test data if
 		self.test_input = self.qd.get('test_transform_input', None)
-
-		logger.debug("##########################################")		
 
 
 	def test_user_input(self):

--- a/core/spark/jobs.py
+++ b/core/spark/jobs.py
@@ -953,5 +953,11 @@ def get_job_db_bounds(job):
 	}
 
 
+def transform_record_id(**kwargs):
+
+	'''
+	
+	'''
+	pass
 
 

--- a/core/static/core/combine.css
+++ b/core/static/core/combine.css
@@ -16,6 +16,12 @@ body {
 	padding: 0.5rem 1rem;
 	margin-bottom: 0.5rem;
 }
+.code_style {
+	font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+	color: #e83e8c;
+	font-size: 87.5%;
+	word-break: break-word;
+}
 .container {
 	max-width: 95%;
 }

--- a/core/templates/core/configuration.html
+++ b/core/templates/core/configuration.html
@@ -119,7 +119,7 @@
 						</tr>
 					{% endfor %}
 				</table>
-				<p><a href="{% url 'test_validation_scenario' %}"><button type="button" class="btn btn-success btn-sm">Test Record Identifier Transformation Scenario</button></a></p>
+				<p><a href="{% url 'test_rits' %}"><button type="button" class="btn btn-success btn-sm">Test Record Identifier Transformation Scenario</button></a></p>
 			</div>
 		</div>
 	</div>

--- a/core/templates/core/configuration.html
+++ b/core/templates/core/configuration.html
@@ -60,7 +60,7 @@
 						<tr>
 							<td>{{transformation.id}}</td>
 							<td>{{transformation.name}}</td>
-							<td>{{transformation.transformation_type}}</td>
+							<td>{{transformation.get_transformation_type_display}}</td>
 							<td><code>{{transformation.filepath}}</code></td>
 							<td><a href="{% url 'transformation_scenario_payload' trans_id=transformation.id %}">{% if transformation.transformation_type == 'xslt' %}View XSL{% elif transformation.transformation_type == 'python' %}View Python{% endif %}</a></td>
 						</tr>
@@ -87,13 +87,39 @@
 						<tr>
 							<td>{{vs.id}}</td>
 							<td>{{vs.name}}</td>
-							<td>{{vs.validation_type}}</td>
+							<td>{{vs.get_validation_type_display}}</td>
 							<td><code>{{vs.filepath}}</code></td>
 							<td><a href="{% url 'validation_scenario_payload' vs_id=vs.id %}">View Validation Payload</a></td>
 						</tr>
 					{% endfor %}
 				</table>
 				<p><a href="{% url 'test_validation_scenario' %}"><button type="button" class="btn btn-success btn-sm">Test Validation Scenario</button></a></p>
+			</div>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-md-12">
+			<h3>Record Identifier Transformation Scenarios</h3>
+			<p>NEED TEXT HERE</p>
+			<div>
+				<table class="table table-bordered table-hover">
+					<tr>
+						<th>ID</th>
+						<th>Name</th>
+						<th>Type</th>
+						<th>Target</th>
+					</tr>
+					{% for rt in rits %}
+						<tr>
+							<td>{{rt.id}}</td>
+							<td>{{rt.name}}</td>
+							<td>{{rt.get_transformation_type_display}}</td>
+							<td>{{rt.get_transformation_target_display}}</td>
+						</tr>
+					{% endfor %}
+				</table>
+				<p><a href="{% url 'test_validation_scenario' %}"><button type="button" class="btn btn-success btn-sm">Test Record Identifier Transformation Scenario</button></a></p>
 			</div>
 		</div>
 	</div>

--- a/core/templates/core/job_analysis.html
+++ b/core/templates/core/job_analysis.html
@@ -39,9 +39,12 @@
 						<!-- Record Validation Selection -->
 						{% include 'core/record_validation_select.html' %}
 
+					</div>
+					<div class="col-md-6">
+
 						<!-- Record Identifier Transformation -->
 						{% include 'core/record_identifier_transform.html' %}
-
+						
 					</div>
 				</div>
 

--- a/core/templates/core/job_harvest_oai.html
+++ b/core/templates/core/job_harvest_oai.html
@@ -66,12 +66,18 @@
 				</div>
 
 				<div class="row">
-					<div class="col-md-12">
+					<div class="col-md-6">
 						<!-- Indexing Mapping Selection -->
 						{% include 'core/index_mapping_select.html' %}
 
 						<!-- Record Validation Selection -->
 						{% include 'core/record_validation_select.html' %}
+					</div>
+					<div class="col-md-6">
+
+						<!-- Record Identifier Transformation -->
+						{% include 'core/record_identifier_transform.html' %}
+						
 					</div>
 				</div>
 

--- a/core/templates/core/job_harvest_oai.html
+++ b/core/templates/core/job_harvest_oai.html
@@ -11,57 +11,62 @@
 	</div>
 
 	<div class="row">
-		<div class="col-md-6">
+		<div class="col-md-12">
 			<form method="POST" action="{% url 'job_harvest_oai' org_id=record_group.organization.id record_group_id=record_group.id %}">
 
 				{% csrf_token %}
 
-				<!-- optional job details -->
-				{% include 'core/job_optional_details.html' %}
+				<div class="row">
+					<div class="col-md-6">
 
-				<!-- OAI endpoint -->
-				<div class="form-group">
-					<label for="oai_endpoint_id">Select OAI endpoint to use</label>
-					<select class="form-control" id="oai_endpoint_id" name="oai_endpoint_id" required>
-						<option value="">Select an oai endpoint...</option>
-						{% for oai_endpoint in oai_endpoints %}
-							<option value="{{ oai_endpoint.id }}">{{ oai_endpoint.name }}</option>
-						{% endfor %}						
-					</select>
-				</div>
+						<!-- optional job details -->
+						{% include 'core/job_optional_details.html' %}
 
-				<!-- optional OAI endpoint defaults overrides -->				
-				<div id="oai_endpoint_defaults" style="background-color:#E4E4E3; padding:10px; border-radius:10px; margin-bottom:20px; display:none;">
-					<p class="text-danger font-weight-bold">Below are default settings for this configured OAI Endpoint, but can be selectively overridden for this job</p>
-					
-					<div class="form-group">
-						<label for="verb">OAI Verb</label>
-						<select class="form-control" id="verb" name="verb">
-							<option value="">Select OAI verb...</option>
-							<option value="ListRecords">ListRecords</option>
-							<option value="ListSets">ListSets</option>						
-						</select>
-					</div>
+						<!-- OAI endpoint -->
+						<div class="form-group">
+							<label for="oai_endpoint_id">Select OAI endpoint to use</label>
+							<select class="form-control" id="oai_endpoint_id" name="oai_endpoint_id" required>
+								<option value="">Select an oai endpoint...</option>
+								{% for oai_endpoint in oai_endpoints %}
+									<option value="{{ oai_endpoint.id }}">{{ oai_endpoint.name }}</option>
+								{% endfor %}						
+							</select>
+						</div>
 
-					<div class="form-group">
-						<label for="metadataPrefix">OAI metadata prefix</label>
-						<input type="text" class="form-control" id="metadataPrefix" name="metadataPrefix" placeholder="e.g. mods, MODS, oai_dc, etc.">
-					</div>
+						<!-- optional OAI endpoint defaults overrides -->				
+						<div id="oai_endpoint_defaults" style="background-color:#E4E4E3; padding:10px; border-radius:10px; margin-bottom:20px; display:none;">
+							<p class="text-danger font-weight-bold">Below are default settings for this configured OAI Endpoint, but can be selectively overridden for this job</p>
+							
+							<div class="form-group">
+								<label for="verb">OAI Verb</label>
+								<select class="form-control" id="verb" name="verb">
+									<option value="">Select OAI verb...</option>
+									<option value="ListRecords">ListRecords</option>
+									<option value="ListSets">ListSets</option>						
+								</select>
+							</div>
 
-					<div class="form-group">
-						<label for="scope_type">Scope type</label>
-						<select class="form-control" id="scope_type" name="scope_type">
-							<option value="">Select scope type...</option>
-							<option value="setList">setList</option>
-							<option value="whiteList">whiteList</option>
-							<option value="blackList">blackList</option>
-							<option value="harvestAllSets">harvestAllSets</option>					
-						</select>
-					</div>
+							<div class="form-group">
+								<label for="metadataPrefix">OAI metadata prefix</label>
+								<input type="text" class="form-control" id="metadataPrefix" name="metadataPrefix" placeholder="e.g. mods, MODS, oai_dc, etc.">
+							</div>
 
-					<div class="form-group">
-						<label for="scope_value">Scope value</label>
-						<input type="text" class="form-control" id="scope_value" name="scope_value" placeholder="set1,set2,set3 (comma separated)">						
+							<div class="form-group">
+								<label for="scope_type">Scope type</label>
+								<select class="form-control" id="scope_type" name="scope_type">
+									<option value="">Select scope type...</option>
+									<option value="setList">setList</option>
+									<option value="whiteList">whiteList</option>
+									<option value="blackList">blackList</option>
+									<option value="harvestAllSets">harvestAllSets</option>					
+								</select>
+							</div>
+
+							<div class="form-group">
+								<label for="scope_value">Scope value</label>
+								<input type="text" class="form-control" id="scope_value" name="scope_value" placeholder="set1,set2,set3 (comma separated)">						
+							</div>
+						</div>
 					</div>
 				</div>
 

--- a/core/templates/core/job_harvest_static_xml.html
+++ b/core/templates/core/job_harvest_static_xml.html
@@ -118,12 +118,18 @@
 				</div>
 				
 				<div class="row">
-					<div class="col-md-12">
+					<div class="col-md-6">
 						<!-- Indexing Mapping Selection -->
 						{% include 'core/index_mapping_select.html' %}
 
 						<!-- Record Validation Selection -->
 						{% include 'core/record_validation_select.html' %}
+					</div>
+					<div class="col-md-6">
+
+						<!-- Record Identifier Transformation -->
+						{% include 'core/record_identifier_transform.html' %}
+						
 					</div>
 				</div>
 

--- a/core/templates/core/job_merge.html
+++ b/core/templates/core/job_merge.html
@@ -54,11 +54,14 @@
 						{% include 'core/index_mapping_select.html' %}
 
 						<!-- Record Validation Selection -->
-						{% include 'core/record_validation_select.html' %}
+						{% include 'core/record_validation_select.html' %}						
+
+					</div>
+					<div class="col-md-6">
 
 						<!-- Record Identifier Transformation -->
 						{% include 'core/record_identifier_transform.html' %}
-
+						
 					</div>
 				</div>
 

--- a/core/templates/core/job_transform.html
+++ b/core/templates/core/job_transform.html
@@ -46,9 +46,12 @@
 						<!-- Record Validation Selection -->
 						{% include 'core/record_validation_select.html' %}
 
+					</div>
+					<div class="col-md-6">
+
 						<!-- Record Identifier Transformation -->
 						{% include 'core/record_identifier_transform.html' %}
-
+						
 					</div>
 				</div>
 				

--- a/core/templates/core/record_identifier_transform.html
+++ b/core/templates/core/record_identifier_transform.html
@@ -7,173 +7,30 @@
 				
 				<h5>Transform Record Identifier</h5>
 
-				<p>For all Records in this Job, transform the Record's <code>record_id</code> identifier that is used for publishing and uniqueness checks.  Select a pre-existing <code>record_id</code> transformation if they exist, or run configure and apply a transformation for this job only.</p>
+				<p>For Records in this Job, optionally transform the Record's <code>record_id</code> -- used for publishing and uniqueness checks -- with a pre-existing Record Identifier Transformation Scenario.</p>
 				
 				<div class="row">
 					<div class="col-md-12" style="padding:20px;">
 
 						{% if rits|length > 0 %}
-							{% for rt in rits %}
-								
-								<div class="form-check">
-								  <input class="form-check-input" type="checkbox" value="{{ rt.id }}" id="rits_{{ rt.id }}" name="rits" {% if rt.default_run %}checked{% endif %}>
-								  <label class="form-check-label" for="rits_{{ rt.id }}">
-								    {{ rt.name }}
-								  </label>
-								</div>
 
-							{% endfor %}
+							<div class="form-group">
+								<select class="form-control" id="rits" name="rits" required>
+									<option value=''>Select a Record Identifier Transformation Scenario...</option>
+									{% for rt in rits %}
+										<option value='{{ rt.id }}'>{{ rt.name }}</option>
+									{% endfor %}					
+								</select>
+							</div>
+
 						{% else %}
 							<p class="font-weight-bold"style="margin-bottom:0px;">No pre-existing transformations found. <a href="{% url 'configuration' %}">Create one!</a></p>
 						{% endif %}
 
 					</div>
 				</div>
-				
-				<div class="row">
-					<div class="col-md-12">
-						<p><button type="button" class="btn btn-outline-dark btn-sm" onclick="$('#record_id_transform_options').fadeToggle();">Setup <code>record_id</code> transformation for this job only</button></p>
-					</div>
-				</div>
-
-				<div class="row">
-					<div class="col-md-12">
-						<div id="record_id_transform_options" style="display:none;">
-
-							<div class="form-group">
-								<label for="record_id_transform_target">First, select what will be used as input for the transformation process:</label>
-								<select class="form-control" id="record_id_transform_target" name="record_id_transform_target">
-									<option value=''>Select one...</option>
-									<option value='record_id'>Record's identifier</option>
-									<option value='document'>Record's XML document</option>
-								</select>
-							</div>
-
-							<!-- tabbed input for different transformation types -->					
-							<div class="form-group">
-								<label for="record_id_transform_type">Next, select the transformation type and enter the transformation parameters in the spaces provided:</label>
-								<select class="form-control" id="record_id_transform_type" name="record_id_transform_type">
-									<option value=''>Select one...</option>
-									<option value='regex'>Regular Expression</option>
-									<option value='python'>Python Code Snippet</option>
-									<option value='xpath'>XPath Expression</option>
-								</select>
-							</div>
-
-							<ul id="type_payload_tabs" class="nav nav-tabs" style="display:none;">
-								<li class="nav-item">
-									<a class="nav-link" data-toggle="tab" href="#regex_tab">Regex</a>
-								</li>
-								<li class="nav-item">
-									<a class="nav-link" data-toggle="tab" href="#python_tab">Python</a>
-								</li>
-								<li class="nav-item">
-									<a class="nav-link" data-toggle="tab" href="#xpath_tab">XPath</a>
-								</li>
-							</ul>
-
-							<div class="tab-content">
-
-								<div id="regex_tab" class="tab-pane container" style="margin-top:20px; margin-bottom:20px; margin-left:0px;">						
-									<div class="form-group">
-										<label for="regex_match_payload">Regex match pattern:</label>
-										<input type="text" class="form-control" id="regex_match_payload" name="regex_match_payload"/>
-									</div>
-									<div class="form-group">
-										<label for="regex_replace_payload">Regex replace pattern:</label>
-										<input type="text" class="form-control" id="regex_replace_payload" name="regex_replace_payload"/>
-									</div>
-								</div>
-
-								<div id="python_tab" class="tab-pane container" style="margin-top:20px; margin-bottom:20px; margin-left:0px;">
-									<div class="form-group">
-										<label for="python_payload">Python code for transformation:</label>
-										<p>Current debug requirements: function named <code>transform_identifier(test_input)</code> with single argument for input payload (<code>test_input</code>, identifier or raw XML).</p>
-										<textarea class="form-control" id="python_payload" name="python_payload" rows="3"></textarea>
-									</div>
-								</div>
-
-								<div id="xpath_tab" class="tab-pane container" style="margin-top:20px; margin-bottom:20px; margin-left:0px;">
-									<div class="form-group">
-										<label for="xpath_payload">XPath expression:</label>
-										<input type="text" class="form-control" id="xpath_payload" name="xpath_payload"/>
-									</div>
-								</div>
-
-							</div>
-
-							<!-- test identifier transform -->
-							<div style="padding:20px; background-color:#e2e2e2;">
-								<h6>Test Identifier Transformation (optional)</h6>
-
-								<p>Using the boxes below, test a transformation before finalizing and running with the Job.  In the textarea, paste either an example Record's raw XML document, or the string of an identifier.  The identifier transformation settings from above will operate over the pasted input and show what a resulting identifier would look like.</p>
-
-								<div class="form-group">
-									<label for="test_transform_input">Enter test input payload below (Record document XML or identifier string):</label>
-									<textarea class="form-control" id="test_transform_input" name="test_transform_input" rows="3"></textarea>
-								</div>
-
-								<div class="form-group">
-									<label for="test_transform_output">Test Record identifier output:</label>
-									<input type="text" class="form-control" id="test_transform_output" name="test_transform_output"/>
-								</div>
-
-								<p><button type="button" class="btn btn-success btn-sm" id="test_record_id_transform">Test Validation</button></p>
-
-							</div>
-
-						</div>
-
-					</div>
-				</div>
 			</div>
 		</div>
 	</div>
-
-	<script>
-
-		$(document).ready(function(){
-			
-			// test record_id transformation
-			$("#test_record_id_transform").click(function(){
-
-				$.ajax({
-					type: "POST",
-					url: "{% url 'test_record_id_transform' %}",
-					data: {
-						'record_id_transform_target':$("#record_id_transform_target").val(),
-						'record_id_transform_type':$("#record_id_transform_type").val(),
-						'regex_match_payload':$("#regex_match_payload").val(),
-						'regex_replace_payload':$("#regex_replace_payload").val(),
-						'python_payload':$("#python_payload").val(),
-						'xpath_payload':$("#xpath_payload").val(),
-						'test_transform_input':$("#test_transform_input").val(),
-						'csrfmiddlewaretoken': '{{ csrf_token }}'
-					},
-					dataType:'json',
-					success: function(data){																		
-						console.log(data);
-						$("#test_transform_output").val(data.results);
-					}			
-				});
-
-			});
-
-
-			// listen for transformation type change and show inputs
-			$("#record_id_transform_type").change(function(){
-				type_val = $("#record_id_transform_type").val();
-				if (type_val != ''){
-					$('#type_payload_tabs a[href="#'+type_val+'_tab"]').tab('show');
-				}
-				else {
-					$(".tab-content .tab-pane").removeClass('active');
-					$("#type_payload_tabs .nav-item").removeClass('active');
-				}
-			})
-
-		});
-
-	</script>
-
+				
 {% endblock %}

--- a/core/templates/core/record_identifier_transform.html
+++ b/core/templates/core/record_identifier_transform.html
@@ -16,8 +16,8 @@
 							{% for rt in rits %}
 								
 								<div class="form-check">
-								  <input class="form-check-input" type="checkbox" value="{{ rt.id }}" id="validation_scenario_{{ rt.id }}" name="validation_scenario" {% if rt.default_run %}checked{% endif %}>
-								  <label class="form-check-label" for="validation_scenario_{{ rt.id }}">
+								  <input class="form-check-input" type="checkbox" value="{{ rt.id }}" id="rits_{{ rt.id }}" name="rits" {% if rt.default_run %}checked{% endif %}>
+								  <label class="form-check-label" for="rits_{{ rt.id }}">
 								    {{ rt.name }}
 								  </label>
 								</div>

--- a/core/templates/core/record_identifier_transform.html
+++ b/core/templates/core/record_identifier_transform.html
@@ -30,8 +30,6 @@
 					</div>
 				</div>
 				
-				<!-- end placeholder -->
-
 				<div class="row">
 					<div class="col-md-12">
 						<p><button type="button" class="btn btn-outline-dark btn-sm" onclick="$('#record_id_transform_options').fadeToggle();">Setup <code>record_id</code> transformation for this job only</button></p>

--- a/core/templates/core/record_identifier_transform.html
+++ b/core/templates/core/record_identifier_transform.html
@@ -15,7 +15,7 @@
 						{% if rits|length > 0 %}
 
 							<div class="form-group">
-								<select class="form-control" id="rits" name="rits" required>
+								<select class="form-control" id="rits" name="rits">
 									<option value=''>Select a Record Identifier Transformation Scenario...</option>
 									{% for rt in rits %}
 										<option value='{{ rt.id }}'>{{ rt.name }}</option>

--- a/core/templates/core/record_identifier_transform.html
+++ b/core/templates/core/record_identifier_transform.html
@@ -1,77 +1,40 @@
 {% block content %}
 
-	<div id="record_identifier_transformation_pane" class="row" style="display:none;">
+	<div id="record_identifier_transformation_pane" class="row">
 		<div class="col-md-12">
 			
 			<div style="padding:20px; border-radius:10px; background-color:#FFFBD3;">
 				
 				<h5>Transform Record Identifier</h5>
 
-				<p>For all Records in this Job, transform the Record's <code>record_id</code> that is used for downstream publishing and uniqueness checks.  If configured, select desired <code>record_id</code> transformations below:</p>
+				<p>For all Records in this Job, transform the Record's <code>record_id</code> identifier that is used for publishing and uniqueness checks.  Select a pre-existing <code>record_id</code> transformation if they exist, or run configure and apply a transformation for this job only.</p>
+				
+				<div class="row">
+					<div class="col-md-12" style="padding:20px;">
 
-				<!-- placeholders for eventual saved record_id transformation scenarios -->
-				<!-- <div class="col-md-12">
-					<div class="form-check">
-						<table class="table table-bordered">
-							<thead>
-								<tr>
-									<th>transformation name</th>
-									<th>transformation type</th>
-									<th>order</th>									
-								</tr>
-							</thead>
-							<tbody>
-								<tr>
-									<td>normalize whitespace</td>
-									<td>regex</td>
-									<td>
-										<div class="form-group">
-											<select class="form-control rits_ordering" name="rits_1" id="rits_1">
-												<option value='-1'>Do not run</option>
-												<option value='1'>1</option>
-												<option value='2'>2</option>
-												<option value='3'>3</option>												
-											</select>
-										</div>
-									</td>
-								</tr>
-								<tr>
-									<td>pull identifier from XML record</td>
-									<td>XPath</td>
-									<td>
-										<div class="form-group">
-											<select class="form-control rits_ordering" name="rits_2" id="rits_2">
-												<option value='-1'>Do not run</option>
-												<option value='1'>1</option>
-												<option value='2'>2</option>
-												<option value='3'>3</option>												
-											</select>
-										</div>
-									</td>
-								</tr>
-							</tbody>
-						</table>
+						{% if rits|length > 0 %}
+							{% for rt in rits %}
+								
+								<div class="form-check">
+								  <input class="form-check-input" type="checkbox" value="{{ rt.id }}" id="validation_scenario_{{ rt.id }}" name="validation_scenario" {% if rt.default_run %}checked{% endif %}>
+								  <label class="form-check-label" for="validation_scenario_{{ rt.id }}">
+								    {{ rt.name }}
+								  </label>
+								</div>
+
+							{% endfor %}
+						{% else %}
+							<p class="font-weight-bold"style="margin-bottom:0px;">No pre-existing transformations found. <a href="{% url 'configuration' %}">Create one!</a></p>
+						{% endif %}
+
 					</div>
-				</div> -->
-				<script>
-
-					/* add checks that do not allow multiple transformations to use the same ordering */
-					$(document).ready(function(){
-						$(".rits_ordering").change(function(){
-							console.log(this);
-							if ($('select option[value="' + $(this).val() + '"]:selected').length > 1) {
-						      $(this).val('-1').change();
-						      alert('A record_id transformation has already been set for this order.  Please unset or change the order and try again!');
-						    }
-						});	
-					})					
-
-				</script>
+				</div>
+				
 				<!-- end placeholder -->
 
 				<div class="row">
 					<div class="col-md-12">
-						<p>Or, run a new, "ad hoc" <code>record_id</code> transformation for this job only:<br><br><button type="button" class="btn btn-outline-dark btn-sm" onclick="$('#record_id_transform_options').fadeToggle();">ad hoc <code>record_id</code> transformation</button></p>
+						<p><button type="button" class="btn btn-outline-dark btn-sm" onclick="$('#record_id_transform_options').fadeToggle();">Setup <code>record_id</code> transformation for this job only</button></p>
 					</div>
 				</div>
 

--- a/core/templates/core/test_rits.html
+++ b/core/templates/core/test_rits.html
@@ -25,10 +25,10 @@
 	<!-- input paylaod -->
 	<div class="row">
 		<div class="col-md-12">
+
 			<h3>Record Identifier Transformation Payload</h3>
 			<p>Paste/edit your validation schematron or python script in the textbox below, or select from a pre-existing validation scenario to test or edit:</p>
 			
-			<!-- pre-existing Validation Scenario -->
 			<div class="row">
 				<div class="col-md-4">
 					<div class="form-group">
@@ -114,7 +114,8 @@
 				</div>
 			</div>
 
-			<button class="btn btn-success btn-sm" id="test_vs">Test Validation</button>
+			<button class="btn btn-success btn-sm" id="test_rits">Test Record Identifier Transformation</button>
+
 		</div>
 	</div>
 
@@ -196,89 +197,60 @@
 					});	
 				}
 
-				else {
+				// else {
 					
-					// clear validation dropdown type
-					$("#vs_type").val(this.value);
+				// 	// clear validation dropdown type
+				// 	$("#vs_type").val(this.value);
 
-					// clear payload box
-					$("#vs_payload").val('');
-				}
+				// 	// clear payload box
+				// 	$("#vs_payload").val('');
+				// }
 
 			})
 		});
 
 		$(document).ready(function(){
-			$("#test_vs").click(function(){
+			$("#test_rits").click(function(){
 
-				// change this to dynamically grab from selected rows in records table
+				// get selected db row
 				var db_id = sel_row_id;
-
-				// get vs_payload
-				var vs_payload = $("#vs_payload").val();
-
-				// get vs_type
-				var vs_type = $("#vs_type").val();
-
-				// issue ajax request and get parsed validation results
-				$.ajax({
-					type: "POST",
-					url: "{% url 'test_validation_scenario' %}",
-					data: {
-						'db_id':db_id,
-						'vs_payload':vs_payload,
-						'vs_type':vs_type,
-						'vs_name':'temp_vs',
-						'vs_results_format':'parsed',
-						'csrfmiddlewaretoken': '{{ csrf_token }}'
-					},
-					dataType:'json',
-					success: function(data){																		
-						$("#vs_results_parsed").html(JSON.stringify(data, null, 2));
-						$("#vs_results_parsed").each(function(i, block) {
-							hljs.highlightBlock(block);
-						});
-
-						// highlight background
-						if (data.fail_count == 0){
-							$("#vs_results_parsed").css('background-color','#e0ffdf');	
-						}
-						else {
-							$("#vs_results_parsed").css('background-color','#ffe7f4');		
-						}
-					}			
-				});
 
 				// issue ajax request and get raw validation results
 				$.ajax({
 					type: "POST",
-					url: "{% url 'test_validation_scenario' %}",
+					url: "{% url 'test_rits' %}",
 					data: {
 						'db_id':db_id,
-						'vs_payload':vs_payload,
-						'vs_type':vs_type,
-						'vs_name':'temp_vs',
-						'vs_results_format':'raw',
+						'record_id_transform_target':$("#record_id_transform_target").val(),
+						'record_id_transform_type':$("#record_id_transform_type").val(),
+						'regex_match_payload':$("#regex_match_payload").val(),
+						'regex_replace_payload':$("#regex_replace_payload").val(),
+						'python_payload':$("#python_payload").val(),
+						'xpath_payload':$("#xpath_payload").val(),
+						'test_transform_input':$("#test_transform_input").val(),
 						'csrfmiddlewaretoken': '{{ csrf_token }}'
 					},
-					dataType:'text',
+					dataType:'json',
 					success: function(data){
 
-						// hash to translate vs_type to output serialization format
-						vs_type_output_hash = {
-							'sch':'xml',
-							'python':'json'
-						}
+						console.log(data);
 
-						// add raw data to div
-						$("#vs_results_raw").html(escapeHtmlEntities(data));
+						// // hash to translate vs_type to output serialization format
+						// vs_type_output_hash = {
+						// 	'sch':'xml',
+						// 	'python':'json'
+						// }
 
-						// update class for <code> tag for hljs and init
-						$("#vs_results_raw").removeClass();
-						$("#vs_results_raw").addClass(vs_type_output_hash[vs_type]);
-						$("#vs_results_raw").each(function(i, block) {
-							hljs.highlightBlock(block);
-						});
+						// // add raw data to div
+						// $("#vs_results_raw").html(escapeHtmlEntities(data));
+
+						// // update class for <code> tag for hljs and init
+						// $("#vs_results_raw").removeClass();
+						// $("#vs_results_raw").addClass(vs_type_output_hash[vs_type]);
+						// $("#vs_results_raw").each(function(i, block) {
+						// 	hljs.highlightBlock(block);
+						// });
+
 					}			
 				});
 
@@ -402,7 +374,7 @@
 
 				$.ajax({
 					type: "POST",
-					url: "{% url 'test_record_id_transform' %}",
+					url: "{% url 'test_rits' %}",
 					data: {
 						'record_id_transform_target':$("#record_id_transform_target").val(),
 						'record_id_transform_type':$("#record_id_transform_type").val(),

--- a/core/templates/core/test_rits.html
+++ b/core/templates/core/test_rits.html
@@ -52,7 +52,7 @@
 						<label for="record_id_transform_type">Select the transformation typ:</label>
 						<select class="form-control" id="record_id_transform_type" name="record_id_transform_type">
 							<option value=''>Select one...</option>
-							<option value='regex'>Regular Expression</option>
+							<option value='regex'>Python Regular Expression</option>
 							<option value='python'>Python Code Snippet</option>
 							<option value='xpath'>XPath Expression</option>
 						</select>

--- a/core/templates/core/test_rits.html
+++ b/core/templates/core/test_rits.html
@@ -4,11 +4,12 @@
 	
 	<div class="row">
 		<div class="col-md-8">
-			<h2>Test Record Identifier Transformation Scenario <span class="text-danger">(IN PROGRESS)</span></h2>
+			<h2>Test Record Identifier Transformation Scenario (RITS)</h2>			
 			<p><button type="button" class="btn btn-outline-info btn-sm" onclick="$('#validation_instructions').toggle();">Instructions</button></p>
 
 			<div id="validation_instructions" style="display:none;">
 				<h5>Overview</h5>
+				<p class="text-danger">Explantory text needed...</p>
 			</div>		
 
 		</div>
@@ -24,17 +25,14 @@
 
 	<!-- input paylaod -->
 	<div class="row">
-		<div class="col-md-12">
-
-			<h3>Record Identifier Transformation Payload</h3>
-			<p>Paste/edit your validation schematron or python script in the textbox below, or select from a pre-existing validation scenario to test or edit:</p>
+		<div class="col-md-6">			
 			
 			<div class="row">
-				<div class="col-md-4">
+				<div class="col-md-12">
 					<div class="form-group">
 						<label for="rt_exists">Optionally, select a pre-existing Record Identifier Transformation Scenario</label>
 						<select id="rt_exists" class="form-control">
-							<option value=''></option>
+							<option value=''>Select a pre-existing scenario...</option>
 							{% for rt in rits %}
 								<option value="{{rt.id}}">{{rt.name}}</option>
 							{% endfor %}
@@ -63,7 +61,7 @@
 			</div>
 
 			<div class="row" style="display:none;">
-				<div class="col-md-4">
+				<div class="col-md-12">
 					<ul id="type_payload_tabs" class="nav nav-tabs">
 						<li class="nav-item">
 							<a class="nav-link" data-toggle="tab" href="#regex_tab">Regex</a>
@@ -117,20 +115,14 @@
 			<button class="btn btn-success btn-sm" id="test_rits">Test Record Identifier Transformation</button>
 
 		</div>
-	</div>
 
-	<!-- validation results -->
-	<div class="row">
 		<div class="col-md-6">
-			<h4>Parsed Validation Results</h4>
-			<pre><code id="vs_results_parsed" class="json">Parsed results will show here...</code></pre>
-		</div>
-		<div class="col-md-6">
-			<h4>Raw Validation Results</h4>
+			<h5>Results</h5>
 			<div class="form-group">				
-				<!-- <textarea id="vs_results_raw" class="form-control" rows="15">Raw results will show here...</textarea> -->
-				<code id="vs_results_raw">Raw results will show here...</code>
+				<p id="rits_results_raw">Results will show here...</p>
+			</div>
 		</div>
+
 	</div>
 
 	<script>
@@ -138,6 +130,20 @@
 		// global variables
 		var sel_row_id;
 
+		// listen for transformation type change and show inputs
+		$(document).ready(function(){
+			$("#record_id_transform_type").change(function(){
+				type_val = $("#record_id_transform_type").val();
+				if (type_val != ''){
+					$('#type_payload_tabs a[href="#'+type_val+'_tab"]').tab('show');
+				}
+				else {
+					$(".tab-content .tab-pane").removeClass('active');
+					$("#type_payload_tabs .nav-item").removeClass('active');
+				}
+			})
+		});
+			
 		// capture clicked row
 		$(document).ready(function() {
 			$("#datatables_records tbody").on( 'click', 'tr', function () {
@@ -197,15 +203,6 @@
 					});	
 				}
 
-				// else {
-					
-				// 	// clear validation dropdown type
-				// 	$("#vs_type").val(this.value);
-
-				// 	// clear payload box
-				// 	$("#vs_payload").val('');
-				// }
-
 			})
 		});
 
@@ -235,180 +232,21 @@
 
 						console.log(data);
 
-						// // hash to translate vs_type to output serialization format
-						// vs_type_output_hash = {
-						// 	'sch':'xml',
-						// 	'python':'json'
-						// }
+						// show results
 
-						// // add raw data to div
-						// $("#vs_results_raw").html(escapeHtmlEntities(data));
-
-						// // update class for <code> tag for hljs and init
-						// $("#vs_results_raw").removeClass();
-						// $("#vs_results_raw").addClass(vs_type_output_hash[vs_type]);
-						// $("#vs_results_raw").each(function(i, block) {
-						// 	hljs.highlightBlock(block);
-						// });
+						if (data['success'] == true){							
+							$("#rits_results_raw").html("<code class='text-success'>"+data['results']+"</span>");
+						}
+						else {
+							$("#rits_results_raw").html("<code class='text-danger'>"+data['results']+"</span>");
+						}
 
 					}			
 				});
-
-				// https://stackoverflow.com/a/10825766/1196358
-				function escapeHtmlEntities (str) {
-				  // No jQuery, so use string replace.
-				  return str
-				    .replace(/&/g, '&amp;')
-				    .replace(/>/g, '&gt;')
-				    .replace(/</g, '&lt;')
-				    .replace(/"/g, '&quot;');
-				}
 
 			})
 		});
 		
-	</script>
-
-	<!-- INTEGRATE -->
-	<!-- <div class="row">
-		<div class="col-md-12">
-			<p><button type="button" class="btn btn-outline-dark btn-sm" onclick="$('#record_id_transform_options').fadeToggle();">Setup <code>record_id</code> transformation for this job only</button></p>
-		</div>
-	</div>
-
-	<div class="row">
-		<div class="col-md-12">
-			<div id="record_id_transform_options" style="display:none;">
-
-				<div class="form-group">
-					<label for="record_id_transform_target">First, select what will be used as input for the transformation process:</label>
-					<select class="form-control" id="record_id_transform_target" name="record_id_transform_target">
-						<option value=''>Select one...</option>
-						<option value='record_id'>Record's identifier</option>
-						<option value='document'>Record's XML document</option>
-					</select>
-				</div>
-
-				<div class="form-group">
-					<label for="record_id_transform_type">Next, select the transformation type and enter the transformation parameters in the spaces provided:</label>
-					<select class="form-control" id="record_id_transform_type" name="record_id_transform_type">
-						<option value=''>Select one...</option>
-						<option value='regex'>Regular Expression</option>
-						<option value='python'>Python Code Snippet</option>
-						<option value='xpath'>XPath Expression</option>
-					</select>
-				</div>
-
-				<ul id="type_payload_tabs" class="nav nav-tabs" style="display:none;">
-					<li class="nav-item">
-						<a class="nav-link" data-toggle="tab" href="#regex_tab">Regex</a>
-					</li>
-					<li class="nav-item">
-						<a class="nav-link" data-toggle="tab" href="#python_tab">Python</a>
-					</li>
-					<li class="nav-item">
-						<a class="nav-link" data-toggle="tab" href="#xpath_tab">XPath</a>
-					</li>
-				</ul>
-
-				<div class="tab-content">
-
-					<div id="regex_tab" class="tab-pane container" style="margin-top:20px; margin-bottom:20px; margin-left:0px;">						
-						<div class="form-group">
-							<label for="regex_match_payload">Regex match pattern:</label>
-							<input type="text" class="form-control" id="regex_match_payload" name="regex_match_payload"/>
-						</div>
-						<div class="form-group">
-							<label for="regex_replace_payload">Regex replace pattern:</label>
-							<input type="text" class="form-control" id="regex_replace_payload" name="regex_replace_payload"/>
-						</div>
-					</div>
-
-					<div id="python_tab" class="tab-pane container" style="margin-top:20px; margin-bottom:20px; margin-left:0px;">
-						<div class="form-group">
-							<label for="python_payload">Python code for transformation:</label>
-							<p>Current debug requirements: function named <code>transform_identifier(test_input)</code> with single argument for input payload (<code>test_input</code>, identifier or raw XML).</p>
-							<textarea class="form-control" id="python_payload" name="python_payload" rows="3"></textarea>
-						</div>
-					</div>
-
-					<div id="xpath_tab" class="tab-pane container" style="margin-top:20px; margin-bottom:20px; margin-left:0px;">
-						<div class="form-group">
-							<label for="xpath_payload">XPath expression:</label>
-							<input type="text" class="form-control" id="xpath_payload" name="xpath_payload"/>
-						</div>
-					</div>
-
-				</div>
-
-				<div style="padding:20px; background-color:#e2e2e2;">
-					<h6>Test Identifier Transformation (optional)</h6>
-
-					<p>Using the boxes below, test a transformation before finalizing and running with the Job.  In the textarea, paste either an example Record's raw XML document, or the string of an identifier.  The identifier transformation settings from above will operate over the pasted input and show what a resulting identifier would look like.</p>
-
-					<div class="form-group">
-						<label for="test_transform_input">Enter test input payload below (Record document XML or identifier string):</label>
-						<textarea class="form-control" id="test_transform_input" name="test_transform_input" rows="3"></textarea>
-					</div>
-
-					<div class="form-group">
-						<label for="test_transform_output">Test Record identifier output:</label>
-						<input type="text" class="form-control" id="test_transform_output" name="test_transform_output"/>
-					</div>
-
-					<p><button type="button" class="btn btn-success btn-sm" id="test_record_id_transform">Test Validation</button></p>
-
-				</div>
-
-			</div>
-
-		</div>
-	</div> -->
-	
-	<script>
-
-		$(document).ready(function(){
-			
-			// test record_id transformation
-			$("#test_record_id_transform").click(function(){
-
-				$.ajax({
-					type: "POST",
-					url: "{% url 'test_rits' %}",
-					data: {
-						'record_id_transform_target':$("#record_id_transform_target").val(),
-						'record_id_transform_type':$("#record_id_transform_type").val(),
-						'regex_match_payload':$("#regex_match_payload").val(),
-						'regex_replace_payload':$("#regex_replace_payload").val(),
-						'python_payload':$("#python_payload").val(),
-						'xpath_payload':$("#xpath_payload").val(),
-						'test_transform_input':$("#test_transform_input").val(),
-						'csrfmiddlewaretoken': '{{ csrf_token }}'
-					},
-					dataType:'json',
-					success: function(data){																		
-						console.log(data);
-						$("#test_transform_output").val(data.results);
-					}			
-				});
-
-			});
-
-
-			// listen for transformation type change and show inputs
-			$("#record_id_transform_type").change(function(){
-				type_val = $("#record_id_transform_type").val();
-				if (type_val != ''){
-					$('#type_payload_tabs a[href="#'+type_val+'_tab"]').tab('show');
-				}
-				else {
-					$(".tab-content .tab-pane").removeClass('active');
-					$("#type_payload_tabs .nav-item").removeClass('active');
-				}
-			})
-
-		});
-
 	</script>
 
 {% endblock %}

--- a/core/templates/core/test_rits.html
+++ b/core/templates/core/test_rits.html
@@ -1,0 +1,442 @@
+{% extends 'core/base.html' %}
+
+{% block content %}
+	
+	<div class="row">
+		<div class="col-md-8">
+			<h2>Test Record Identifier Transformation Scenario <span class="text-danger">(IN PROGRESS)</span></h2>
+			<p><button type="button" class="btn btn-outline-info btn-sm" onclick="$('#validation_instructions').toggle();">Instructions</button></p>
+
+			<div id="validation_instructions" style="display:none;">
+				<h5>Overview</h5>
+			</div>		
+
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-md-12">
+			<!-- All Records DT table -->
+			{% include 'core/records_dt_table.html' %}
+		</div>
+	</div>
+
+
+	<!-- input paylaod -->
+	<div class="row">
+		<div class="col-md-12">
+			<h3>Record Identifier Transformation Payload</h3>
+			<p>Paste/edit your validation schematron or python script in the textbox below, or select from a pre-existing validation scenario to test or edit:</p>
+			
+			<!-- pre-existing Validation Scenario -->
+			<div class="row">
+				<div class="col-md-4">
+					<div class="form-group">
+						<label for="rt_exists">Optionally, select a pre-existing Record Identifier Transformation Scenario</label>
+						<select id="rt_exists" class="form-control">
+							<option value=''></option>
+							{% for rt in rits %}
+								<option value="{{rt.id}}">{{rt.name}}</option>
+							{% endfor %}
+						</select>
+					</div>
+
+					<div class="form-group">
+						<label for="record_id_transform_target">Select what will be used as input for the transformation process</label>
+						<select class="form-control" id="record_id_transform_target" name="record_id_transform_target">
+							<option value=''>Select one...</option>
+							<option value='record_id'>Record's identifier</option>
+							<option value='document'>Record's XML document</option>
+						</select>
+					</div>
+
+					<div class="form-group">
+						<label for="record_id_transform_type">Select the transformation typ:</label>
+						<select class="form-control" id="record_id_transform_type" name="record_id_transform_type">
+							<option value=''>Select one...</option>
+							<option value='regex'>Regular Expression</option>
+							<option value='python'>Python Code Snippet</option>
+							<option value='xpath'>XPath Expression</option>
+						</select>
+					</div>
+				</div>
+			</div>
+
+			<div class="row" style="display:none;">
+				<div class="col-md-4">
+					<ul id="type_payload_tabs" class="nav nav-tabs">
+						<li class="nav-item">
+							<a class="nav-link" data-toggle="tab" href="#regex_tab">Regex</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" data-toggle="tab" href="#python_tab">Python</a>
+						</li>
+						<li class="nav-item">
+							<a class="nav-link" data-toggle="tab" href="#xpath_tab">XPath</a>
+						</li>
+					</ul>
+				</div>
+			</div>
+
+			<div class="row">
+				<div class="col-md-12">
+
+					<div class="tab-content">
+
+						<div id="regex_tab" class="tab-pane container" style="padding-left:0px; margin-bottom:20px; margin-left:0px;">						
+							<div class="form-group">
+								<label for="regex_match_payload">Regex match pattern:</label>
+								<input type="text" class="form-control" id="regex_match_payload" name="regex_match_payload"/>
+							</div>
+							<div class="form-group">
+								<label for="regex_replace_payload">Regex replace pattern:</label>
+								<input type="text" class="form-control" id="regex_replace_payload" name="regex_replace_payload"/>
+							</div>
+						</div>
+
+						<div id="python_tab" class="tab-pane container" style="padding-left:0px; margin-bottom:20px; margin-left:0px;">
+							<div class="form-group">
+								<label for="python_payload">Python code for transformation:</label>
+								<p>Current debug requirements: function named <code>transform_identifier(test_input)</code> with single argument for input payload (<code>test_input</code>, identifier or raw XML).</p>
+								<textarea class="form-control" id="python_payload" name="python_payload" rows="3"></textarea>
+							</div>
+						</div>
+
+						<div id="xpath_tab" class="tab-pane container" style="padding-left:0px; margin-bottom:20px; margin-left:0px;">
+							<div class="form-group">
+								<label for="xpath_payload">XPath expression:</label>
+								<input type="text" class="form-control" id="xpath_payload" name="xpath_payload"/>
+							</div>
+						</div>
+
+					</div>
+
+				</div>
+			</div>
+
+			<button class="btn btn-success btn-sm" id="test_vs">Test Validation</button>
+		</div>
+	</div>
+
+	<!-- validation results -->
+	<div class="row">
+		<div class="col-md-6">
+			<h4>Parsed Validation Results</h4>
+			<pre><code id="vs_results_parsed" class="json">Parsed results will show here...</code></pre>
+		</div>
+		<div class="col-md-6">
+			<h4>Raw Validation Results</h4>
+			<div class="form-group">				
+				<!-- <textarea id="vs_results_raw" class="form-control" rows="15">Raw results will show here...</textarea> -->
+				<code id="vs_results_raw">Raw results will show here...</code>
+		</div>
+	</div>
+
+	<script>
+
+		// global variables
+		var sel_row_id;
+
+		// capture clicked row
+		$(document).ready(function() {
+			$("#datatables_records tbody").on( 'click', 'tr', function () {
+
+				// loop through and remove other selections
+				$("#datatables_records tbody tr.selected").each(function(i, block){
+					$(block).removeClass('selected');
+				});
+
+				// show selection
+				$(this).toggleClass('selected');
+
+				// get record id
+			    sel_row = $(this).children(":first");
+			    sel_row_id = sel_row.find('code').html()
+			} );
+		});
+
+		// capture pre-existing validation scenarios and paste
+		$(document).ready(function(){
+			$("#rt_exists").change(function(){
+
+				if (this.value != ''){					
+
+					// get payload
+					$.ajax({
+						type: "GET",
+						url: "/combine/configuration/rits/RITS_ID/payload".replace('RITS_ID', $(this).val()),
+						dataType:'json',
+						success: function(data){
+							
+							// update target
+							$("#record_id_transform_target").val(data['transformation_target']);
+
+							// update type
+							$("#record_id_transform_type").val(data['transformation_type']);
+
+							// handle regex
+							if (data['transformation_type'] == 'regex') {
+								$("#regex_match_payload").val(data['regex_match_payload']);
+								$("#regex_replace_payload").val(data['regex_replace_payload']);
+							}
+
+							// handle python
+							if (data['transformation_type'] == 'python') {
+								$("#python_payload").val(data['python_payload']);
+							}
+
+							// handle xpath
+							if (data['transformation_type'] == 'xpath') {
+								$("#xpath_payload").val(data['xpath_payload']);
+							}
+
+							// select pane
+							$('#type_payload_tabs a[href="#'+data['transformation_type']+'_tab"]').tab('show');
+						}			
+					});	
+				}
+
+				else {
+					
+					// clear validation dropdown type
+					$("#vs_type").val(this.value);
+
+					// clear payload box
+					$("#vs_payload").val('');
+				}
+
+			})
+		});
+
+		$(document).ready(function(){
+			$("#test_vs").click(function(){
+
+				// change this to dynamically grab from selected rows in records table
+				var db_id = sel_row_id;
+
+				// get vs_payload
+				var vs_payload = $("#vs_payload").val();
+
+				// get vs_type
+				var vs_type = $("#vs_type").val();
+
+				// issue ajax request and get parsed validation results
+				$.ajax({
+					type: "POST",
+					url: "{% url 'test_validation_scenario' %}",
+					data: {
+						'db_id':db_id,
+						'vs_payload':vs_payload,
+						'vs_type':vs_type,
+						'vs_name':'temp_vs',
+						'vs_results_format':'parsed',
+						'csrfmiddlewaretoken': '{{ csrf_token }}'
+					},
+					dataType:'json',
+					success: function(data){																		
+						$("#vs_results_parsed").html(JSON.stringify(data, null, 2));
+						$("#vs_results_parsed").each(function(i, block) {
+							hljs.highlightBlock(block);
+						});
+
+						// highlight background
+						if (data.fail_count == 0){
+							$("#vs_results_parsed").css('background-color','#e0ffdf');	
+						}
+						else {
+							$("#vs_results_parsed").css('background-color','#ffe7f4');		
+						}
+					}			
+				});
+
+				// issue ajax request and get raw validation results
+				$.ajax({
+					type: "POST",
+					url: "{% url 'test_validation_scenario' %}",
+					data: {
+						'db_id':db_id,
+						'vs_payload':vs_payload,
+						'vs_type':vs_type,
+						'vs_name':'temp_vs',
+						'vs_results_format':'raw',
+						'csrfmiddlewaretoken': '{{ csrf_token }}'
+					},
+					dataType:'text',
+					success: function(data){
+
+						// hash to translate vs_type to output serialization format
+						vs_type_output_hash = {
+							'sch':'xml',
+							'python':'json'
+						}
+
+						// add raw data to div
+						$("#vs_results_raw").html(escapeHtmlEntities(data));
+
+						// update class for <code> tag for hljs and init
+						$("#vs_results_raw").removeClass();
+						$("#vs_results_raw").addClass(vs_type_output_hash[vs_type]);
+						$("#vs_results_raw").each(function(i, block) {
+							hljs.highlightBlock(block);
+						});
+					}			
+				});
+
+				// https://stackoverflow.com/a/10825766/1196358
+				function escapeHtmlEntities (str) {
+				  // No jQuery, so use string replace.
+				  return str
+				    .replace(/&/g, '&amp;')
+				    .replace(/>/g, '&gt;')
+				    .replace(/</g, '&lt;')
+				    .replace(/"/g, '&quot;');
+				}
+
+			})
+		});
+		
+	</script>
+
+	<!-- INTEGRATE -->
+	<!-- <div class="row">
+		<div class="col-md-12">
+			<p><button type="button" class="btn btn-outline-dark btn-sm" onclick="$('#record_id_transform_options').fadeToggle();">Setup <code>record_id</code> transformation for this job only</button></p>
+		</div>
+	</div>
+
+	<div class="row">
+		<div class="col-md-12">
+			<div id="record_id_transform_options" style="display:none;">
+
+				<div class="form-group">
+					<label for="record_id_transform_target">First, select what will be used as input for the transformation process:</label>
+					<select class="form-control" id="record_id_transform_target" name="record_id_transform_target">
+						<option value=''>Select one...</option>
+						<option value='record_id'>Record's identifier</option>
+						<option value='document'>Record's XML document</option>
+					</select>
+				</div>
+
+				<div class="form-group">
+					<label for="record_id_transform_type">Next, select the transformation type and enter the transformation parameters in the spaces provided:</label>
+					<select class="form-control" id="record_id_transform_type" name="record_id_transform_type">
+						<option value=''>Select one...</option>
+						<option value='regex'>Regular Expression</option>
+						<option value='python'>Python Code Snippet</option>
+						<option value='xpath'>XPath Expression</option>
+					</select>
+				</div>
+
+				<ul id="type_payload_tabs" class="nav nav-tabs" style="display:none;">
+					<li class="nav-item">
+						<a class="nav-link" data-toggle="tab" href="#regex_tab">Regex</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" data-toggle="tab" href="#python_tab">Python</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" data-toggle="tab" href="#xpath_tab">XPath</a>
+					</li>
+				</ul>
+
+				<div class="tab-content">
+
+					<div id="regex_tab" class="tab-pane container" style="margin-top:20px; margin-bottom:20px; margin-left:0px;">						
+						<div class="form-group">
+							<label for="regex_match_payload">Regex match pattern:</label>
+							<input type="text" class="form-control" id="regex_match_payload" name="regex_match_payload"/>
+						</div>
+						<div class="form-group">
+							<label for="regex_replace_payload">Regex replace pattern:</label>
+							<input type="text" class="form-control" id="regex_replace_payload" name="regex_replace_payload"/>
+						</div>
+					</div>
+
+					<div id="python_tab" class="tab-pane container" style="margin-top:20px; margin-bottom:20px; margin-left:0px;">
+						<div class="form-group">
+							<label for="python_payload">Python code for transformation:</label>
+							<p>Current debug requirements: function named <code>transform_identifier(test_input)</code> with single argument for input payload (<code>test_input</code>, identifier or raw XML).</p>
+							<textarea class="form-control" id="python_payload" name="python_payload" rows="3"></textarea>
+						</div>
+					</div>
+
+					<div id="xpath_tab" class="tab-pane container" style="margin-top:20px; margin-bottom:20px; margin-left:0px;">
+						<div class="form-group">
+							<label for="xpath_payload">XPath expression:</label>
+							<input type="text" class="form-control" id="xpath_payload" name="xpath_payload"/>
+						</div>
+					</div>
+
+				</div>
+
+				<div style="padding:20px; background-color:#e2e2e2;">
+					<h6>Test Identifier Transformation (optional)</h6>
+
+					<p>Using the boxes below, test a transformation before finalizing and running with the Job.  In the textarea, paste either an example Record's raw XML document, or the string of an identifier.  The identifier transformation settings from above will operate over the pasted input and show what a resulting identifier would look like.</p>
+
+					<div class="form-group">
+						<label for="test_transform_input">Enter test input payload below (Record document XML or identifier string):</label>
+						<textarea class="form-control" id="test_transform_input" name="test_transform_input" rows="3"></textarea>
+					</div>
+
+					<div class="form-group">
+						<label for="test_transform_output">Test Record identifier output:</label>
+						<input type="text" class="form-control" id="test_transform_output" name="test_transform_output"/>
+					</div>
+
+					<p><button type="button" class="btn btn-success btn-sm" id="test_record_id_transform">Test Validation</button></p>
+
+				</div>
+
+			</div>
+
+		</div>
+	</div> -->
+	
+	<script>
+
+		$(document).ready(function(){
+			
+			// test record_id transformation
+			$("#test_record_id_transform").click(function(){
+
+				$.ajax({
+					type: "POST",
+					url: "{% url 'test_record_id_transform' %}",
+					data: {
+						'record_id_transform_target':$("#record_id_transform_target").val(),
+						'record_id_transform_type':$("#record_id_transform_type").val(),
+						'regex_match_payload':$("#regex_match_payload").val(),
+						'regex_replace_payload':$("#regex_replace_payload").val(),
+						'python_payload':$("#python_payload").val(),
+						'xpath_payload':$("#xpath_payload").val(),
+						'test_transform_input':$("#test_transform_input").val(),
+						'csrfmiddlewaretoken': '{{ csrf_token }}'
+					},
+					dataType:'json',
+					success: function(data){																		
+						console.log(data);
+						$("#test_transform_output").val(data.results);
+					}			
+				});
+
+			});
+
+
+			// listen for transformation type change and show inputs
+			$("#record_id_transform_type").change(function(){
+				type_val = $("#record_id_transform_type").val();
+				if (type_val != ''){
+					$('#type_payload_tabs a[href="#'+type_val+'_tab"]').tab('show');
+				}
+				else {
+					$(".tab-content .tab-pane").removeClass('active');
+					$("#type_payload_tabs .nav-item").removeClass('active');
+				}
+			})
+
+		});
+
+	</script>
+
+{% endblock %}

--- a/core/templates/core/test_rits.html
+++ b/core/templates/core/test_rits.html
@@ -84,11 +84,11 @@
 						<div id="regex_tab" class="tab-pane container" style="padding-left:0px; margin-bottom:20px; margin-left:0px;">						
 							<div class="form-group">
 								<label for="regex_match_payload">Regex match pattern:</label>
-								<input type="text" class="form-control" id="regex_match_payload" name="regex_match_payload"/>
+								<input type="text" class="code_style form-control" id="regex_match_payload" name="regex_match_payload"/>
 							</div>
 							<div class="form-group">
 								<label for="regex_replace_payload">Regex replace pattern:</label>
-								<input type="text" class="form-control" id="regex_replace_payload" name="regex_replace_payload"/>
+								<input type="text" class="code_style form-control" id="regex_replace_payload" name="regex_replace_payload"/>
 							</div>
 						</div>
 
@@ -96,14 +96,14 @@
 							<div class="form-group">
 								<label for="python_payload">Python code for transformation:</label>
 								<p>Current debug requirements: function named <code>transform_identifier(test_input)</code> with single argument for input payload (<code>test_input</code>, identifier or raw XML).</p>
-								<textarea class="form-control" id="python_payload" name="python_payload" rows="3"></textarea>
+								<textarea class="code_style form-control" id="python_payload" name="python_payload" rows="3"></textarea>
 							</div>
 						</div>
 
 						<div id="xpath_tab" class="tab-pane container" style="padding-left:0px; margin-bottom:20px; margin-left:0px;">
 							<div class="form-group">
 								<label for="xpath_payload">XPath expression:</label>
-								<input type="text" class="form-control" id="xpath_payload" name="xpath_payload"/>
+								<input type="text" class="code_style form-control" id="xpath_payload" name="xpath_payload"/>
 							</div>
 						</div>
 

--- a/core/templates/core/test_validation_scenario.html
+++ b/core/templates/core/test_validation_scenario.html
@@ -5,7 +5,7 @@
 	<div class="row">
 		<div class="col-md-8">
 			<h2>Test Validation Scenario</h2>
-			<p><button type="button" class="btn btn-outline-info btn-sm" onclick="$('#validation_instructions').toggle();">Instructions</button>
+			<p><button type="button" class="btn btn-outline-info btn-sm" onclick="$('#validation_instructions').toggle();">Instructions</button></p>
 
 			<div id="validation_instructions" style="display:none;">
 

--- a/core/templates/core/test_validation_scenario.html
+++ b/core/templates/core/test_validation_scenario.html
@@ -164,6 +164,7 @@ def test_check_dateIssued_format(record, test_message="check mods:dateIssued is 
 			<div class="form-group">				
 				<!-- <textarea id="vs_results_raw" class="form-control" rows="15">Raw results will show here...</textarea> -->
 				<code id="vs_results_raw">Raw results will show here...</code>
+			</div>
 		</div>
 	</div>
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -87,7 +87,7 @@ urlpatterns = [
 	url(r'^analysis/new$', views.job_analysis, name='job_analysis'),
 
 	# Misc
-	url(r'^misc/test_record_id_transform$', views.test_record_id_transform, name='test_record_id_transform'),
+	# url(r'^misc/test_record_id_transform$', views.test_record_id_transform, name='test_record_id_transform'),
 
 	# general views
 	url(r'^login$', auth_views.login, name='login'),

--- a/core/urls.py
+++ b/core/urls.py
@@ -65,6 +65,8 @@ urlpatterns = [
 	url(r'^configuration/oai_endpoint/(?P<oai_endpoint_id>[0-9]+)/payload$', views.oai_endpoint_payload, name='oai_endpoint_payload'),
 	url(r'^configuration/validation/(?P<vs_id>[0-9]+)/payload$', views.validation_scenario_payload, name='validation_scenario_payload'),
 	url(r'^configuration/test_validation_scenario$', views.test_validation_scenario, name='test_validation_scenario'),
+	url(r'^configuration/rits/(?P<rits_id>[0-9]+)/payload$', views.rits_payload, name='rits_payload'),
+	url(r'^configuration/test_rits$', views.test_rits, name='test_rits'),
 
 	# Publish
 	url(r'^published$', views.published, name='published'),

--- a/core/views.py
+++ b/core/views.py
@@ -954,8 +954,7 @@ def job_merge(request, org_id, record_group_id):
 		validation_scenarios = request.POST.getlist('validation_scenario', [])
 
 		# handle requested record_id transform
-		if request.POST.get('record_id_transform_type', False):			
-			rits = models.RecordIDTransformationScenario(request.POST)
+		rits = request.POST.get('rits')
 
 		# initiate job
 		cjob = models.MergeJob(
@@ -965,7 +964,8 @@ def job_merge(request, org_id, record_group_id):
 			record_group=record_group,
 			input_jobs=input_jobs,
 			index_mapper=index_mapper,
-			validation_scenarios=validation_scenarios
+			validation_scenarios=validation_scenarios,
+			rits=rits
 		)
 		
 		# start job and update status
@@ -1614,7 +1614,7 @@ def test_rits(request):
 				request.POST['test_transform_input'] = record.document
 
 			# instantiate rits and return test
-			rits = models.RecordIDTransformationScenario(request.POST)
+			rits = models.RITSClient(request.POST)
 			return JsonResponse(rits.test_user_input())
 
 		except Exception as e:

--- a/core/views.py
+++ b/core/views.py
@@ -611,6 +611,9 @@ def job_harvest_oai(request, org_id, record_group_id):
 		# get validation scenarios
 		validation_scenarios = models.ValidationScenario.objects.all()
 
+		# get record identifier transformation scenarios
+		rits = models.RecordIdentifierTransformationScenario.objects.all()
+
 		# get index mappers
 		index_mappers = models.IndexMappers.get_mappers()
 
@@ -619,6 +622,7 @@ def job_harvest_oai(request, org_id, record_group_id):
 				'record_group':record_group,
 				'oai_endpoints':oai_endpoints,
 				'validation_scenarios':validation_scenarios,
+				'rits':rits,
 				'index_mappers':index_mappers,
 				'breadcrumbs':breadcrumb_parser(request.path)
 			})
@@ -655,6 +659,9 @@ def job_harvest_oai(request, org_id, record_group_id):
 		# get requested validation scenarios
 		validation_scenarios = request.POST.getlist('validation_scenario', [])
 
+		# handle requested record_id transform
+		rits = request.POST.get('rits')
+
 		# initiate job
 		cjob = models.HarvestOAIJob(			
 			job_name=job_name,
@@ -664,7 +671,8 @@ def job_harvest_oai(request, org_id, record_group_id):
 			oai_endpoint=oai_endpoint,
 			overrides=overrides,
 			index_mapper=index_mapper,
-			validation_scenarios=validation_scenarios
+			validation_scenarios=validation_scenarios,
+			rits=rits
 		)
 		
 		# start job and update status
@@ -693,6 +701,9 @@ def job_harvest_static_xml(request, org_id, record_group_id, hash_payload_filena
 
 	# get index mappers
 	index_mappers = models.IndexMappers.get_mappers()
+
+	# get record identifier transformation scenarios
+	rits = models.RecordIdentifierTransformationScenario.objects.all()
 	
 	# if GET, prepare form
 	if request.method == 'GET':
@@ -701,6 +712,7 @@ def job_harvest_static_xml(request, org_id, record_group_id, hash_payload_filena
 		return render(request, 'core/job_harvest_static_xml.html', {
 				'record_group':record_group,
 				'validation_scenarios':validation_scenarios,
+				'rits':rits,
 				'index_mappers':index_mappers,
 				'breadcrumbs':breadcrumb_parser(request.path)
 			})
@@ -768,6 +780,9 @@ def job_harvest_static_xml(request, org_id, record_group_id, hash_payload_filena
 		# get requested validation scenarios
 		validation_scenarios = request.POST.getlist('validation_scenario', [])
 
+		# handle requested record_id transform
+		rits = request.POST.get('rits')
+
 		# initiate job
 		cjob = models.HarvestStaticXMLJob(			
 			job_name=job_name,
@@ -776,7 +791,8 @@ def job_harvest_static_xml(request, org_id, record_group_id, hash_payload_filena
 			record_group=record_group,
 			index_mapper=index_mapper,
 			payload_dict=payload_dict,
-			validation_scenarios=validation_scenarios
+			validation_scenarios=validation_scenarios,
+			rits=rits
 		)
 		
 		# start job and update status
@@ -815,6 +831,9 @@ def job_transform(request, org_id, record_group_id):
 		# get index mappers
 		index_mappers = models.IndexMappers.get_mappers()
 
+		# get record identifier transformation scenarios
+		rits = models.RecordIdentifierTransformationScenario.objects.all()
+
 		# get job lineage for all jobs (filtered to input jobs scope)
 		ld = models.Job.get_all_jobs_lineage(directionality='downstream', jobs_query_set=input_jobs)
 
@@ -825,6 +844,7 @@ def job_transform(request, org_id, record_group_id):
 				'input_jobs':input_jobs,
 				'transformations':transformations,
 				'validation_scenarios':validation_scenarios,
+				'rits':rits,
 				'index_mappers':index_mappers,
 				'job_lineage_json':json.dumps(ld),
 				'breadcrumbs':breadcrumb_parser(request.path)
@@ -862,6 +882,9 @@ def job_transform(request, org_id, record_group_id):
 		# get requested validation scenarios
 		validation_scenarios = request.POST.getlist('validation_scenario', [])
 
+		# handle requested record_id transform
+		rits = request.POST.get('rits')
+
 		# initiate job
 		cjob = models.TransformJob(
 			job_name=job_name,
@@ -871,7 +894,8 @@ def job_transform(request, org_id, record_group_id):
 			input_job=input_job,
 			transformation=transformation,
 			index_mapper=index_mapper,
-			validation_scenarios=validation_scenarios
+			validation_scenarios=validation_scenarios,
+			rits=rits
 		)
 		
 		# start job and update status
@@ -1722,6 +1746,9 @@ def job_analysis(request):
 		# get index mappers
 		index_mappers = models.IndexMappers.get_mappers()
 
+		# get record identifier transformation scenarios
+		rits = models.RecordIdentifierTransformationScenario.objects.all()
+
 		# get job lineage for all jobs (filtered to input jobs scope)
 		ld = models.Job.get_all_jobs_lineage(directionality='downstream', jobs_query_set=input_jobs)
 
@@ -1730,6 +1757,7 @@ def job_analysis(request):
 				'job_select_type':'multiple',				
 				'input_jobs':input_jobs,
 				'validation_scenarios':validation_scenarios,
+				'rits':rits,
 				'index_mappers':index_mappers,
 				'job_lineage_json':json.dumps(ld)				
 			})
@@ -1762,6 +1790,9 @@ def job_analysis(request):
 		# get requested validation scenarios
 		validation_scenarios = request.POST.getlist('validation_scenario', [])
 
+		# handle requested record_id transform
+		rits = request.POST.get('rits')
+
 		# initiate job
 		cjob = models.AnalysisJob(
 			job_name=job_name,
@@ -1769,7 +1800,8 @@ def job_analysis(request):
 			user=request.user,			
 			input_jobs=input_jobs,
 			index_mapper=index_mapper,
-			validation_scenarios=validation_scenarios
+			validation_scenarios=validation_scenarios,
+			rits=rits
 		)
 		
 		# start job and update status

--- a/core/views.py
+++ b/core/views.py
@@ -1433,11 +1433,15 @@ def configuration(request):
 	# get all validation scenarios
 	validation_scenarios = models.ValidationScenario.objects.all()
 
+	# get record identifier transformation scenarios
+	rits = models.RecordIdentifierTransformationScenario.objects.all()
+
 	# return
 	return render(request, 'core/configuration.html', {
 			'transformations':transformations,
 			'oai_endpoints':oai_endpoints,
 			'validation_scenarios':validation_scenarios,
+			'rits':rits,
 			'breadcrumbs':breadcrumb_parser(request.path)
 		})
 

--- a/core/views.py
+++ b/core/views.py
@@ -1594,23 +1594,31 @@ def test_rits(request):
 		logger.debug('testing record identifier transformation')		
 		logger.debug(request.POST)
 
-		# make POST data mutable
-		request.POST._mutable = True
+		try:
 
-		# get record
-		record = models.Record.objects.get(pk=int(request.POST.get('db_id')))
+			# make POST data mutable
+			request.POST._mutable = True
 
-		# determine testing type
-		if request.POST['record_id_transform_target'] == 'record_id':			
-			logger.debug('configuring test for record_id')
-			request.POST['test_transform_input'] = record.record_id
-		elif request.POST['record_id_transform_target'] == 'document':
-			logger.debug('configuring test for record_id')
-			request.POST['test_transform_input'] = record.document
+			# get record
+			if request.POST.get('db_id', False):
+				record = models.Record.objects.get(pk=int(request.POST.get('db_id')))
+			else:
+				return JsonResponse({'results':'Please select a record from the table above!','success':False})
 
-		# instantiate rits and return test
-		rits = models.RecordIDTransformationScenario(request.POST)
-		return JsonResponse(rits.test_user_input())
+			# determine testing type
+			if request.POST['record_id_transform_target'] == 'record_id':			
+				logger.debug('configuring test for record_id')
+				request.POST['test_transform_input'] = record.record_id
+			elif request.POST['record_id_transform_target'] == 'document':
+				logger.debug('configuring test for record_id')
+				request.POST['test_transform_input'] = record.document
+
+			# instantiate rits and return test
+			rits = models.RecordIDTransformationScenario(request.POST)
+			return JsonResponse(rits.test_user_input())
+
+		except Exception as e:
+			return JsonResponse({'results':str(e), 'success':False})
 
 
 ####################################################################

--- a/core/views.py
+++ b/core/views.py
@@ -903,6 +903,9 @@ def job_merge(request, org_id, record_group_id):
 		# get validation scenarios
 		validation_scenarios = models.ValidationScenario.objects.all()
 
+		# get record identifier transformation scenarios
+		rits = models.RecordIdentifierTransformationScenario.objects.all()
+
 		# get index mappers
 		index_mappers = models.IndexMappers.get_mappers()
 
@@ -915,6 +918,7 @@ def job_merge(request, org_id, record_group_id):
 				'record_group':record_group,
 				'input_jobs':input_jobs,
 				'validation_scenarios':validation_scenarios,
+				'rits':rits,
 				'index_mappers':index_mappers,
 				'job_lineage_json':json.dumps(ld),
 				'breadcrumbs':breadcrumb_parser(request.path)


### PR DESCRIPTION
This PR introduces the ability to transform a Record's `record_id` through pre-configured "Record Identifier Transformation Scenarios (RITS)".  Regular expressions, python code snippets, and XPath are all supported.

An example of where this might be helpful is harvesting from an OAI endpoint that has changed its OAI set structure, thereby changing the OAI identifier associated with a record.  With these transformations -- optionally applied to any job -- it is possible to establish a workflow that would "fix" the identifiers by aligning them with what is currently in DPLA already.

e.g. a record may be harvested with an identifier like:
```
oai:digital.library.wayne.edu:wayne:DoctorPa1877b21375318
```

but a user of Combine understands that it should be:
```
oai:digital.library.wayne.eduwsudor_dpla:oai:digital.library.wayne.edu:wayne:DoctorPa1877b21375318
```

A regular expression transformation would fairly easily convert this identifier, and all others from a job.

